### PR TITLE
fix demo on ios

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -62,8 +62,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div>Three</div>
         </iron-pages>
         <script>
-          document.addEventListener('click', function(e) {
-            var pages = document.querySelector('iron-pages');
+          var pages = document.querySelector('iron-pages');
+          pages.addEventListener('click', function(e) {
             pages.selectNext();
           });
         </script>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-pages/issues/42

On ios, the `document.click` handler doesn't fire (possibly because the pages eat the click? did not investigate), but putting the handler on something that makes more sense works fine.

@e111077 👀 🙏 ?
