### PR TITLE
from polymerelements to PolymerElements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "polymer": "Polymer/polymer#1.9 - 2"
   },
   "devDependencies": {
-    "iron-component-page": "polymerelements/iron-component-page#1 - 2",
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
     "paper-styles": "PolymerElements/paper-styles#1 - 2",
     "web-component-tester": "^6.0.0",
@@ -32,14 +32,14 @@
   "variants": {
     "1.x": {
       "dependencies": {
-        "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^1.0.0",
-        "iron-selector": "polymerelements/iron-selector#^1.0.0",
+        "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
+        "iron-selector": "PolymerElements/iron-selector#^1.0.0",
         "polymer": "Polymer/polymer#^1.9"
       },
       "devDependencies": {
-        "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
-        "iron-demo-helpers": "polymerelements/iron-demo-helpers#^1.0.0",
-        "paper-styles": "polymerelements/paper-styles#^1.0.2",
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.0.2",
         "web-component-tester": "^4.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       },


### PR DESCRIPTION
This pull requests want to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "PolymerElements" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.